### PR TITLE
Handle no inputs case in decode vote

### DIFF
--- a/scripts/decode_executable.py
+++ b/scripts/decode_executable.py
@@ -11,7 +11,7 @@ warnings.filterwarnings("ignore")
 
 RICH_CONSOLE = RichConsole(file=sys.stdout)
 DAO_VOTING_CONTRACTS = {
-    "ownership": "0xe478de485ad2fe566d49342cbd03e49ed7db3356",
+    "ownership": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
     "parameter": "0xbcff8b0b9419b9a88c44546519b1e909cf330399",
     "emergency": "0x1115c9b3168563354137cdc60efb66552dd50678",
 }
@@ -22,6 +22,8 @@ def get_evm_script(vote_id: str, voting_contract: str) -> str:
 
 
 def format_fn_inputs(abi, inputs):
+    if len(inputs) == 0:
+        return ""
 
     if len(inputs) == 1:
         argname = abi.inputs[0].name


### PR DESCRIPTION
There's a smol bug when `inputs` has zero length in `decode_vote`.

Example:

```console
$ ape run decode_executable decode --target ownership --vote_id 404
INFO: Starting 'Hardhat node' process.
[15:46:01] Decoding ownership VoteID: 404                                                                 decode_executable.py:64
Traceback (most recent call last):
[...snipped..]
  File "/Users/suh/git/curve-dao-operations/scripts/decode_executable.py", line 93, in decode_vote
    formatted_inputs = format_fn_inputs(fn, inputs)
  File "/Users/suh/git/curve-dao-operations/scripts/decode_executable.py", line 35, in format_fn_inputs
    argname = abi.inputs[-1].name
IndexError: list index out of range
```

After the fix:

```console
$ ape run decode_executable decode --target ownership --vote_id 404
INFO: Starting 'Hardhat node' process.
[15:50:37] Decoding ownership VoteID: 404                                                                 decode_executable.py:66
[15:50:40] Call via agent: 0x40907540d8a6C65c637785e8f8B742ae6b0b9968                                     decode_executable.py:96
            ├─ To: 0xbeF434E2aCF0FBaD1f0579d2376fED0d1CfC4217
            ├─ Function: price_w
            └─ Inputs:


           Call via agent: 0x40907540d8a6C65c637785e8f8B742ae6b0b9968                                     decode_executable.py:96
            ├─ To: 0xC9332fdCB1C491Dcc683bAe86Fe3cb70360738BC
            ├─ Function: add_market
            └─ Inputs:
               ├─ token: 0x18084fbA666a33d37592fA2633fD49a74DD93a88
               ├─ A: 100
               ├─ fee: 6000000000000000
               ├─ admin_fee: 0
               ├─ _price_oracle_contract: 0xbeF434E2aCF0FBaD1f0579d2376fED0d1CfC4217
               ├─ monetary_policy: 0xb8687d7dc9d8fa32fabde63E19b2dBC9bB8B2138
               ├─ loan_discount: 90000000000000000
               ├─ liquidation_discount: 60000000000000000
               └─ debt_ceiling: 50000000000000000000000000
```