### PR TITLE
Refactor decode

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+max-complexity = 10
+max-line-length = 110
+ignore = 
+	E203
+	E501
+        P103
+	W503
+        F405

--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 [flake8]
 max-complexity = 10
 max-line-length = 110
-ignore = 
+ignore =
 	E203
 	E501
         P103

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: unitary
 on: ["push", "pull_request"]
 
 env:
-  ETHERSCAN_TOKEN: ${{secrets.ETHERSCAN_TOKEN}}
+  ETHERSCAN_API_KEY: ${{secrets.ETHERSCAN_API_KEY}}
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}
   WEB3_ALCHEMY_API_KEY: ${{secrets.WEB3_ALCHEMY_API_KEY}}
   IPFS_PROJECT_ID: ${{secrets.IPFS_PROJECT_ID}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
 
@@ -25,7 +25,7 @@ jobs:
         run: npm ci
 
       - name: Setup Python 3.10.4
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.10.4
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Input args:
 An example of its usage is show in the following:
 
 ```
-% ape run decode_executable decode --vote_id 223 --target ownership
+$ ape run decode_executable decode --vote-type ownership --vote-id 223
 ```
 
 Output:

--- a/curve_dao/__init__.py
+++ b/curve_dao/__init__.py
@@ -1,43 +1,5 @@
-from curve_dao.modules import smartwallet_checker  # noqa
+__all__ = ["smartwallet_checker", "make_vote"]
 
-from .vote_utils import make_vote  # noqa
+from curve_dao.modules import smartwallet_checker
 
-CURVE_DAO_OWNERSHIP = {
-    "agent": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
-    "voting": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
-    "token": "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2",
-    "quorum": 30,
-}
-
-CURVE_DAO_PARAM = {
-    "agent": "0x4eeb3ba4f221ca16ed4a0cc7254e2e32df948c5f",
-    "voting": "0xbcff8b0b9419b9a88c44546519b1e909cf330399",
-    "token": "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2",
-    "quorum": 15,
-}
-
-EMERGENCY_DAO = {
-    "forwarder": "0xf409Ce40B5bb1e4Ef8e97b1979629859c6d5481f",
-    "agent": "0x00669DF67E4827FCc0E48A1838a8d5AB79281909",
-    "voting": "0x1115c9b3168563354137cdc60efb66552dd50678",
-    "token": "0x4c0947B16FB1f755A2D32EC21A0c4181f711C500",
-    "quorum": 51,
-}
-
-veCRV = "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2"
-CRV = "0xD533a949740bb3306d119CC777fa900bA034cd52"
-CONVEX_VOTERPROXY = "0x989AEB4D175E16225E39E87D0D97A3360524AD80"
-# 2-coin factory cryptopools only;
-# tricrypto-ng factory admin is already the OWNERSHIP agent
-CRYPTOSWAP_OWNER_PROXY = "0x5a8fdC979ba9b6179916404414F7BA4D8B77C8A1"
-
-
-def select_target(vote_type: str):
-
-    match vote_type:
-        case "ownership":
-            return CURVE_DAO_OWNERSHIP
-        case "parameter":
-            return CURVE_DAO_PARAM
-        case "emergency":
-            return EMERGENCY_DAO
+from .vote_utils import make_vote

--- a/curve_dao/addresses.py
+++ b/curve_dao/addresses.py
@@ -1,0 +1,45 @@
+CURVE_DAO_OWNERSHIP = {
+    "agent": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+    "voting": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
+    "token": "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2",
+    "quorum": 30,
+}
+
+CURVE_DAO_PARAM = {
+    "agent": "0x4eeb3ba4f221ca16ed4a0cc7254e2e32df948c5f",
+    "voting": "0xbcff8b0b9419b9a88c44546519b1e909cf330399",
+    "token": "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2",
+    "quorum": 15,
+}
+
+EMERGENCY_DAO = {
+    "forwarder": "0xf409Ce40B5bb1e4Ef8e97b1979629859c6d5481f",
+    "agent": "0x00669DF67E4827FCc0E48A1838a8d5AB79281909",
+    "voting": "0x1115c9b3168563354137cdc60efb66552dd50678",
+    "token": "0x4c0947B16FB1f755A2D32EC21A0c4181f711C500",
+    "quorum": 51,
+}
+
+VOTING_ESCROW = "0x5f3b5DfEb7B28CDbD7FAba78963EE202a494e2A2"
+veCRV = VOTING_ESCROW
+CRV = "0xD533a949740bb3306d119CC777fa900bA034cd52"
+CONVEX_VOTERPROXY = "0x989AEB4D175E16225E39E87D0D97A3360524AD80"
+# 2-coin factory cryptopools only;
+# tricrypto-ng factory admin is already the OWNERSHIP agent
+CRYPTOSWAP_OWNER_PROXY = "0x5a8fdC979ba9b6179916404414F7BA4D8B77C8A1"
+
+
+def get_dao_voting_contract(vote_type: str):
+    target = select_target(vote_type)
+    return target["voting"]
+
+
+def select_target(vote_type: str):
+
+    match vote_type:
+        case "ownership":
+            return CURVE_DAO_OWNERSHIP
+        case "parameter":
+            return CURVE_DAO_PARAM
+        case "emergency":
+            return EMERGENCY_DAO

--- a/curve_dao/decoder_utils.py
+++ b/curve_dao/decoder_utils.py
@@ -15,7 +15,6 @@ except ImportError:
     from eth_abi import decode as decode_abi
 
 
-
 def get_type_strings(abi_params: List, substitutions: Optional[Dict] = None) -> List:
     types_list = []
     if substitutions is None:

--- a/curve_dao/decoder_utils.py
+++ b/curve_dao/decoder_utils.py
@@ -3,12 +3,17 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import ape
 from ape.exceptions import DecodingError
 from ape.utils.abi import Struct
-from eth_abi import decode_abi
 from eth_abi.exceptions import InsufficientDataBytes
 from eth_hash.auto import keccak
 from eth_utils import humanize_hash, is_hex_address, to_checksum_address
 from ethpm_types import HexBytes
 from ethpm_types.abi import MethodABI
+
+try:
+    from eth_abi import decode_abi
+except ImportError:
+    from eth_abi import decode as decode_abi
+
 
 
 def get_type_strings(abi_params: List, substitutions: Optional[Dict] = None) -> List:

--- a/curve_dao/ipfs.py
+++ b/curve_dao/ipfs.py
@@ -35,12 +35,14 @@ def get_description_from_ipfs_hash(ipfs_hash: str):
             auth=(os.getenv("IPFS_PROJECT_ID"), os.getenv("IPFS_PROJECT_SECRET")),
             timeout=5,
         )
+        response.raise_for_status()
     except requests.Timeout:
         return "IPFS timed out.  Possibly the description is no longer pinned."
     except requests.ConnectionError as e:
         return f"IPFS connection error: {e}"
+    except requests.HTTPError as e:
+        return f"IPFS request error: {e}"
 
-    response.raise_for_status()
     response_string = response.content.decode("utf-8")
     json_string = []
     in_json = False

--- a/curve_dao/ipfs.py
+++ b/curve_dao/ipfs.py
@@ -1,6 +1,5 @@
 import json
 import os
-from typing import Dict
 
 import ape
 import requests

--- a/curve_dao/ipfs.py
+++ b/curve_dao/ipfs.py
@@ -1,11 +1,9 @@
 import json
 import os
-import sys
-from typing import Dict, List
+from typing import Dict
 
 import ape
 import requests
-from ape.logging import logger
 
 from .addresses import get_dao_voting_contract
 

--- a/curve_dao/ipfs.py
+++ b/curve_dao/ipfs.py
@@ -1,0 +1,70 @@
+import json
+import os
+import sys
+from typing import Dict, List
+
+import ape
+import requests
+from ape.logging import logger
+
+from .addresses import get_dao_voting_contract
+
+
+def get_ipfs_hash_from_description(description: str):
+    """Uploads vote description to IPFS and returns the IPFS hash.
+
+    NOTE: needs environment variables for infura IPFS access. Please
+    set up an IPFS project to generate project id and project secret!
+    """
+    text = json.dumps({"text": description})
+    response = requests.post(
+        "https://ipfs.infura.io:5001/api/v0/add",
+        files={"file": text},
+        auth=(os.getenv("IPFS_PROJECT_ID"), os.getenv("IPFS_PROJECT_SECRET")),
+    )
+    assert (
+        200 <= response.status_code < 400
+    ), f"POST to IPFS failed: {response.status_code}"
+    return response.json()["Hash"]
+
+
+def get_description_from_ipfs_hash(ipfs_hash: str):
+    response = requests.post(
+        f"https://ipfs.infura.io:5001/api/v0/get?arg={ipfs_hash}",
+        auth=(os.getenv("IPFS_PROJECT_ID"), os.getenv("IPFS_PROJECT_SECRET")),
+    )
+    response.raise_for_status()
+    response_string = response.content.decode("utf-8")
+    json_string = []
+    in_json = False
+    for c in response_string:
+        if c == "{":
+            in_json = True
+        if in_json:
+            json_string.append(c)
+        if c == "}":
+            break
+    json_string = "".join(json_string)
+    return json.loads(json_string)
+
+
+def get_ipfs_hash_from_vote_id(vote_type, vote_id):
+    voting_contract_address = get_dao_voting_contract(vote_type)
+    voting_contract = ape.project.Voting.at(voting_contract_address)
+    snapshot_block = voting_contract.getVote(vote_id)["snapshotBlock"]
+    vote_events = voting_contract.StartVote.query(
+        "voteId",
+        "metadata",
+        start_block=snapshot_block - 1,
+        stop_block=snapshot_block + 1,
+    )
+    vote_row = vote_events.loc[vote_events["voteId"] == vote_id]
+    ipfs_hash = vote_row["metadata"].iloc[0]
+    ipfs_hash = ipfs_hash[5:]
+    return ipfs_hash
+
+
+def get_description_from_vote_id(vote_id, target):
+    ipfs_hash = get_ipfs_hash_from_vote_id(target, vote_id)
+    description = get_description_from_ipfs_hash(ipfs_hash)
+    return description

--- a/curve_dao/ipfs.py
+++ b/curve_dao/ipfs.py
@@ -29,10 +29,17 @@ def get_ipfs_hash_from_description(description: str):
 
 
 def get_description_from_ipfs_hash(ipfs_hash: str):
-    response = requests.post(
-        f"https://ipfs.infura.io:5001/api/v0/get?arg={ipfs_hash}",
-        auth=(os.getenv("IPFS_PROJECT_ID"), os.getenv("IPFS_PROJECT_SECRET")),
-    )
+    try:
+        response = requests.post(
+            f"https://ipfs.infura.io:5001/api/v0/get?arg={ipfs_hash}",
+            auth=(os.getenv("IPFS_PROJECT_ID"), os.getenv("IPFS_PROJECT_SECRET")),
+            timeout=5,
+        )
+    except requests.Timeout:
+        return "IPFS timed out.  Possibly the description is no longer pinned."
+    except requests.ConnectionError as e:
+        return f"IPFS connection error: {e}"
+
     response.raise_for_status()
     response_string = response.content.decode("utf-8")
     json_string = []

--- a/curve_dao/simulate.py
+++ b/curve_dao/simulate.py
@@ -3,7 +3,7 @@ import pprint
 import ape
 from ape.logging import logger
 
-from curve_dao import CONVEX_VOTERPROXY
+from .addresses import CONVEX_VOTERPROXY
 
 
 def simulate(vote_id: int, voting_contract: str):

--- a/curve_dao/vote_utils.py
+++ b/curve_dao/vote_utils.py
@@ -32,10 +32,8 @@ def prepare_vote_script(target: Dict, actions: List[Tuple]) -> str:
     for address, fn_name, *args in actions:
         contract = ape.Contract(address)
         fn = getattr(contract, fn_name)
-        calldata = fn.as_transaction(*args, sender=agent).data
-        agent_calldata = agent.execute.as_transaction(
-            address, 0, calldata, sender=voting
-        ).data
+        calldata = bytes(fn.encode_input(*args))
+        agent_calldata = bytes(agent.execute.encode_input(address, 0, calldata))
         length = bytes.fromhex(hex(len(agent_calldata.hex()) // 2)[2:].zfill(8))
         evm_script = (
             evm_script + bytes.fromhex(agent.address[2:]) + length + agent_calldata

--- a/curve_dao/vote_utils.py
+++ b/curve_dao/vote_utils.py
@@ -1,9 +1,7 @@
-import json
 import warnings
 from typing import Dict, List, Tuple
 
 import ape
-import requests
 from ape.logging import logger
 
 from .addresses import get_dao_voting_contract

--- a/curve_dao/vote_utils.py
+++ b/curve_dao/vote_utils.py
@@ -1,11 +1,17 @@
 import json
 import os
+import sys
 import warnings
 from typing import Dict, List, Tuple
 
 import ape
 import requests
 from ape.logging import logger
+
+from curve_dao.decoder_utils import decode_input
+
+warnings.filterwarnings("ignore")
+
 
 warnings.filterwarnings("ignore")
 
@@ -90,3 +96,84 @@ def make_vote(target: Dict, actions: List[Tuple], description: str, vote_creator
     )
 
     return tx
+
+
+def decode_vote_script(script):
+    idx = 4
+
+    votes = []
+    while idx < len(script):
+
+        # get target contract address:
+        target = ape.Contract(script[idx : idx + 20])
+        idx += 20
+
+        length = int(script[idx : idx + 4].hex(), 16)
+        idx += 4
+
+        # calldata to execute for the dao:
+        calldata = script[idx : idx + length]
+        idx += length
+
+        fn, inputs = decode_input(target, calldata)
+        agent = None
+
+        # print decoded vote:
+        if calldata[:4].hex() == "0xb61d27f6":
+            agent = target
+            target = ape.Contract(inputs[0])
+            fn, inputs = decode_input(target, inputs[2])
+            inputs_with_names = get_inputs_with_names(fn, inputs)
+            formatted_inputs = format_fn_inputs(inputs_with_names)
+            formatted_output = (
+                f"Call via agent: [yellow]{agent}[/]\n"
+                f" ├─ [bold]To[/]: [green]{target}[/]\n"
+                f" ├─ [bold]Function[/]: [yellow]{fn.name}[/]\n"
+                f" └─ [bold]Inputs[/]: \n{formatted_inputs}\n"
+            )
+        else:
+            inputs_with_names = get_inputs_with_names(fn, inputs)
+            formatted_inputs = format_fn_inputs(inputs_with_names)
+            formatted_output = (
+                f"Direct call\n "
+                f" ├─ [bold]To[/]: [green]{target}[/]\n"
+                f" ├─ [bold]Function[/]: [yellow]{fn.name}[/]\n"
+                f" └─ [bold]Inputs[/]: {formatted_inputs}\n"
+            )
+
+        vote = {
+            "agent": agent.address if agent else None,
+            "target": target.address,
+            "function": fn.name,
+            "inputs": inputs_with_names,
+            "formatted_output": formatted_output,
+        }
+        votes.append(vote)
+
+    return votes
+
+
+def get_inputs_with_names(abi, inputs):
+    arg_names = []
+    for i in range(len(inputs)):
+        argname = abi.inputs[i].name
+        arg_names.append(argname)
+
+    inputs_with_names = list(zip(arg_names, inputs))
+    return inputs_with_names
+
+
+def format_fn_inputs(inputs_with_names):
+    if len(inputs_with_names) == 0:
+        return ""
+
+    if len(inputs_with_names) == 1:
+        name, arg = inputs_with_names[0]
+        return f"    └─ [bold]{name}[/]: [yellow]{arg}[/]"
+
+    formatted_args = ""
+    for name, arg in inputs_with_names[:-1]:
+        formatted_args += f"    ├─ [bold]{name}[/]: [yellow]{arg}[/]\n"
+    name, arg = inputs_with_names[-1]
+    formatted_args += f"    └─ [bold]{name}[/]: [yellow]{arg}[/]"
+    return formatted_args

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,631 @@
+[MAIN]
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Clear in-memory caches upon conclusion of linting. Useful if running pylint
+# in a server-like mode.
+clear-cache-post-run=no
+
+# Load and enable all available extensions. Use --list-extensions to see a list
+# all available extensions.
+#enable-all-extensions=
+
+# In error mode, messages with a category besides ERROR or FATAL are
+# suppressed, and no reports are done by default. Error mode is compatible with
+# disabling specific errors.
+#errors-only=
+
+# Always return a 0 (non-error) status code, even if lint errors are found.
+# This is primarily useful in continuous integration scripts.
+#exit-zero=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-allow-list=
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code. (This is an alternative name to extension-pkg-allow-list
+# for backward compatibility.)
+extension-pkg-whitelist=
+
+# Return non-zero exit code if any of these messages/categories are detected,
+# even if score is above --fail-under value. Syntax same as enable. Messages
+# specified are enabled, while categories only check already-enabled messages.
+fail-on=
+
+# Specify a score threshold under which the program will exit with error.
+fail-under=10
+
+# Interpret the stdin as a python script, whose filename needs to be passed as
+# the module_or_package argument.
+#from-stdin=
+
+# Files or directories to be skipped. They should be base names, not paths.
+ignore=CVS
+
+# Add files or directories matching the regular expressions patterns to the
+# ignore-list. The regex matches against paths and can be in Posix or Windows
+# format. Because '\\' represents the directory delimiter on Windows systems,
+# it can't be used as an escape character.
+ignore-paths=
+
+# Files or directories matching the regular expression patterns are skipped.
+# The regex matches against base names, not paths. The default value ignores
+# Emacs file locks
+ignore-patterns=^\.#
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use, and will cap the count on Windows to
+# avoid hangs.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Minimum Python version to use for version dependent checks. Will default to
+# the version used to run pylint.
+py-version=3.10
+
+# Discover python modules and packages in the file system subtree.
+recursive=no
+
+# Add paths to the list of the source roots. Supports globbing patterns. The
+# source root is an absolute path or a path relative to the current working
+# directory used to determine a package namespace for modules located under the
+# source root.
+source-roots=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# In verbose mode, extra non-checker-related info will be displayed.
+#verbose=
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style. If left empty, argument names will be checked with the set
+# naming style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style. If left empty, attribute names will be checked with the set naming
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Bad variable names regexes, separated by a comma. If names match any regex,
+# they will always be refused
+bad-names-rgxs=
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style. If left empty, class attribute names will be checked
+# with the set naming style.
+#class-attribute-rgx=
+
+# Naming style matching correct class constant names.
+class-const-naming-style=UPPER_CASE
+
+# Regular expression matching correct class constant names. Overrides class-
+# const-naming-style. If left empty, class constant names will be checked with
+# the set naming style.
+#class-const-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style. If left empty, class names will be checked with the set naming style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style. If left empty, constant names will be checked with the set naming
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style. If left empty, function names will be checked with the set
+# naming style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Good variable names regexes, separated by a comma. If names match any regex,
+# they will always be accepted
+good-names-rgxs=
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style. If left empty, inline iteration names will be checked
+# with the set naming style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style. If left empty, method names will be checked with the set naming style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style. If left empty, module names will be checked with the set naming style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct type alias names. If left empty, type
+# alias names will be checked with the set naming style.
+#typealias-rgx=
+
+# Regular expression matching correct type variable names. If left empty, type
+# variable names will be checked with the set naming style.
+#typevar-rgx=
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style. If left empty, variable names will be checked with the set
+# naming style.
+#variable-rgx=
+
+
+[CLASSES]
+
+# Warn about protected attribute access inside special methods
+check-protected-access-in-special-methods=no
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      asyncSetUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make,os._exit
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# List of regular expressions of class ancestor names to ignore when counting
+# public methods (see R0903)
+exclude-too-few-public-methods=
+
+# List of qualified class names to ignore when counting class parents (see
+# R0901)
+ignored-parents=
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when caught.
+overgeneral-exceptions=builtins.BaseException,builtins.Exception
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=88
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow explicit reexports by alias from a package __init__.
+allow-reexport-from-package=no
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=
+
+# Output a graph (.gv or any supported image format) of external dependencies
+# to the given file (report RP0402 must not be disabled).
+ext-import-graph=
+
+# Output a graph (.gv or any supported image format) of all (i.e. internal and
+# external) dependencies to the given file (report RP0402 must not be
+# disabled).
+import-graph=
+
+# Output a graph (.gv or any supported image format) of internal dependencies
+# to the given file (report RP0402 must not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[LOGGING]
+
+# The type of string formatting that logging methods do. `old` means using %
+# formatting, `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, CONTROL_FLOW, INFERENCE, INFERENCE_FAILURE,
+# UNDEFINED.
+confidence=HIGH,
+           CONTROL_FLOW,
+           INFERENCE,
+           INFERENCE_FAILURE,
+           UNDEFINED
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then re-enable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[METHOD_ARGS]
+
+# List of qualified names (i.e., library.method) which require a timeout
+# parameter e.g. 'requests.api.get,requests.api.post'
+timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+# Regular expression of note tags to take in consideration.
+notes-rgx=
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit,argparse.parse_error
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'fatal', 'error', 'warning', 'refactor',
+# 'convention', and 'info' which contain the number of messages in each
+# category, as well as 'statement' which is the total number of statements
+# analyzed. This score is used by the global evaluation report (RP0004).
+evaluation=max(0, 0 if fatal else 10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10))
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+#output-format=
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[SIMILARITIES]
+
+# Comments are removed from the similarity computation
+ignore-comments=yes
+
+# Docstrings are removed from the similarity computation
+ignore-docstrings=yes
+
+# Imports are removed from the similarity computation
+ignore-imports=yes
+
+# Signatures are removed from the similarity computation
+ignore-signatures=yes
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. No available dictionaries : You need to install
+# both the python package and the system dependency for enchant to work..
+spelling-dict=
+
+# List of comma separated words that should be considered directives if they
+# appear at the beginning of a comment and should not be checked.
+spelling-ignore-comment-directives=fmt: on,fmt: off,noqa:,noqa,nosec,isort:skip,mypy:
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=no
+
+# This flag controls whether the implicit-str-concat should generate a warning
+# on implicit string concatenation in sequences defined over several lines.
+check-str-concat-over-line-jumps=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of symbolic message names to ignore for Mixin members.
+ignored-checks-for-mixins=no-member,
+                          not-async-context-manager,
+                          not-context-manager,
+                          attribute-defined-outside-init
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local,argparse.Namespace
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# Regex pattern to define which classes are considered mixins.
+mixin-class-rgx=.*[Mm]ixin
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of names allowed to shadow builtins
+allowed-redefined-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,10 @@ requires = ["setuptools", "wheel"]
 
 [tool.setuptools.packages.find]
 include = ["curve_dao*"]
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"

--- a/scripts/decode_executable.py
+++ b/scripts/decode_executable.py
@@ -3,7 +3,6 @@ import warnings
 
 import ape
 import click
-from curve_dao.decoder_utils import decode_input
 from curve_dao.ipfs import get_description_from_vote_id
 from curve_dao.vote_utils import decode_vote_script, get_vote_script
 from rich.console import Console as RichConsole

--- a/scripts/decode_executable.py
+++ b/scripts/decode_executable.py
@@ -4,7 +4,8 @@ import warnings
 import ape
 import click
 from curve_dao.decoder_utils import decode_input
-from curve_dao.vote_utils import decode_vote_script
+from curve_dao.vote_utils import (decode_vote_script,
+                                  get_vote_description_from_ifps_hash)
 from rich.console import Console as RichConsole
 
 warnings.filterwarnings("ignore")
@@ -52,8 +53,23 @@ def decode(network, target: str, vote_id: int):
     if not script:
         RICH_CONSOLE.log("[red] VoteID not found in any DAO voting contract [/red]")
         return
+    snapshot_block = ape.project.Voting.at(DAO_VOTING_CONTRACTS[target]).getVote(
+        vote_id
+    )["snapshotBlock"]
 
     votes = decode_vote_script(script)
+    new_vote_event = ape.project.Voting.at(DAO_VOTING_CONTRACTS[target]).StartVote
+    all_new_vote_events = new_vote_event.query(
+        "voteId",
+        "metadata",
+        start_block=snapshot_block - 1,
+        stop_block=snapshot_block + 1,
+    )
+    vote_row = all_new_vote_events.loc[all_new_vote_events["voteId"] == vote_id]
+    ipfs_hash = vote_row["metadata"].iloc[0]
+    ipfs_hash = ipfs_hash[5:]
+    description = get_vote_description_from_ifps_hash(ipfs_hash)
+    RICH_CONSOLE.log(description)
     for vote in votes:
         formatted_output = vote["formatted_output"]
         RICH_CONSOLE.log(formatted_output)

--- a/scripts/decode_executable.py
+++ b/scripts/decode_executable.py
@@ -3,9 +3,10 @@ import warnings
 
 import ape
 import click
+from rich.console import Console as RichConsole
+
 from curve_dao.ipfs import get_description_from_vote_id
 from curve_dao.vote_utils import decode_vote_script, get_vote_script
-from rich.console import Console as RichConsole
 
 warnings.filterwarnings("ignore")
 

--- a/scripts/decode_executable.py
+++ b/scripts/decode_executable.py
@@ -29,23 +29,23 @@ def cli():
 )
 @ape.cli.network_option()
 @click.option(
-    "--target",
+    "--vote-type",
     "-t",
     type=click.Choice(["ownership", "parameter"]),
     required=True,
 )
-@click.option("--vote_id", "-v", type=int, default=0)
-def decode(network, target: str, vote_id: int):
+@click.option("--vote-id", "-v", type=int, default=0)
+def decode(network, vote_type: str, vote_id: int):
 
-    RICH_CONSOLE.log(f"Decoding {target} VoteID: {vote_id}")
+    RICH_CONSOLE.log(f"Decoding {vote_type} VoteID: {vote_id}")
 
     # get script from voting data:
-    script = get_vote_script(vote_id, target)
+    script = get_vote_script(vote_id, vote_type)
     if not script:
         RICH_CONSOLE.log("[red] VoteID not found in any DAO voting contract [/red]")
         return
 
-    description = get_description_from_vote_id(vote_id, target)
+    description = get_description_from_vote_id(vote_id, vote_type)
     RICH_CONSOLE.log(description)
 
     votes = decode_vote_script(script)

--- a/scripts/decode_executable.py
+++ b/scripts/decode_executable.py
@@ -5,25 +5,14 @@ import ape
 import click
 from curve_dao.decoder_utils import decode_input
 from curve_dao.vote_utils import (decode_vote_script,
-                                  get_vote_description_from_ifps_hash)
+                                  get_description_from_ipfs_hash,
+                                  get_description_from_vote_id,
+                                  get_vote_script)
 from rich.console import Console as RichConsole
 
 warnings.filterwarnings("ignore")
 
 RICH_CONSOLE = RichConsole(file=sys.stdout)
-DAO_VOTING_CONTRACTS = {
-    "ownership": "0xE478de485ad2fe566d49342Cbd03E49ed7DB3356",
-    "parameter": "0xbcff8b0b9419b9a88c44546519b1e909cf330399",
-    "emergency": "0x1115c9b3168563354137cdc60efb66552dd50678",
-}
-
-
-def get_evm_script(vote_id: str, target: str) -> str:
-    voting_contract_address = DAO_VOTING_CONTRACTS[target]
-    voting_contract = ape.project.Voting.at(voting_contract_address)
-    vote = voting_contract.getVote(vote_id)
-    script = vote["script"]
-    return script
 
 
 @click.group(
@@ -53,37 +42,15 @@ def decode(network, target: str, vote_id: int):
     RICH_CONSOLE.log(f"Decoding {target} VoteID: {vote_id}")
 
     # get script from voting data:
-    script = get_evm_script(vote_id, target)
+    script = get_vote_script(vote_id, target)
     if not script:
         RICH_CONSOLE.log("[red] VoteID not found in any DAO voting contract [/red]")
         return
 
-    description = get_description_from_vote_id(target, vote_id)
+    description = get_description_from_vote_id(vote_id, target)
     RICH_CONSOLE.log(description)
 
     votes = decode_vote_script(script)
     for vote in votes:
         formatted_output = vote["formatted_output"]
         RICH_CONSOLE.log(formatted_output)
-
-
-def get_ipfs_hash_from_vote_id(target, vote_id):
-    voting_contract_address = DAO_VOTING_CONTRACTS[target]
-    voting_contract = ape.project.Voting.at(voting_contract_address)
-    snapshot_block = voting_contract.getVote(vote_id)["snapshotBlock"]
-    vote_events = voting_contract.StartVote.query(
-        "voteId",
-        "metadata",
-        start_block=snapshot_block - 1,
-        stop_block=snapshot_block + 1,
-    )
-    vote_row = vote_events.loc[vote_events["voteId"] == vote_id]
-    ipfs_hash = vote_row["metadata"].iloc[0]
-    ipfs_hash = ipfs_hash[5:]
-    return ipfs_hash
-
-
-def get_description_from_vote_id(target, vote_id):
-    ipfs_hash = get_ipfs_hash_from_vote_id(target, vote_id)
-    description = get_vote_description_from_ifps_hash(ipfs_hash)
-    return description

--- a/scripts/decode_executable.py
+++ b/scripts/decode_executable.py
@@ -4,10 +4,8 @@ import warnings
 import ape
 import click
 from curve_dao.decoder_utils import decode_input
-from curve_dao.vote_utils import (decode_vote_script,
-                                  get_description_from_ipfs_hash,
-                                  get_description_from_vote_id,
-                                  get_vote_script)
+from curve_dao.ipfs import get_description_from_vote_id
+from curve_dao.vote_utils import decode_vote_script, get_vote_script
 from rich.console import Console as RichConsole
 
 warnings.filterwarnings("ignore")

--- a/scripts/set_vote.py
+++ b/scripts/set_vote.py
@@ -1,8 +1,8 @@
 import ape
 import click
 from ape.logging import logger
-
-from curve_dao import make_vote, select_target
+from curve_dao import make_vote
+from curve_dao.addresses import get_dao_voting_contract
 from curve_dao.modules.smartwallet_checker import whitelist_vecrv_lock
 
 
@@ -22,7 +22,7 @@ def cli():
 @click.option("--description", "-d", type=str, required=True)
 def whitelist(network, account, addr, description):
 
-    target = select_target("ownership")
+    target = get_dao_voting_contract("ownership")
     tx = make_vote(
         target=target,
         actions=[whitelist_vecrv_lock(addr)],

--- a/scripts/set_vote.py
+++ b/scripts/set_vote.py
@@ -1,6 +1,7 @@
 import ape
 import click
 from ape.logging import logger
+
 from curve_dao import make_vote
 from curve_dao.addresses import get_dao_voting_contract
 from curve_dao.modules.smartwallet_checker import whitelist_vecrv_lock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import ape
 import pytest
+
 from curve_dao.addresses import CRV, CURVE_DAO_OWNERSHIP, CURVE_DAO_PARAM, VOTING_ESCROW
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import ape
 import pytest
-
-from curve_dao import CURVE_DAO_OWNERSHIP, CURVE_DAO_PARAM
+from curve_dao.addresses import CRV, CURVE_DAO_OWNERSHIP, CURVE_DAO_PARAM, VOTING_ESCROW
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,5 +25,21 @@ def parameter_voting():
 
 @pytest.fixture(scope="module")
 def vote_deployer():
-    # random vecrv holder
-    return ape.accounts["0x9c5083dd4838E120Dbeac44C052179692Aa5dAC5"]
+    """
+    Fund test user account with CRV and then lock for >= 2500 veCRV.
+
+    Since we fork mainnet for tests, we need a "random" account to avoid
+    cooldown issues with the real user creating a vote in the same period.
+    """
+    user = ape.accounts.test_accounts[0]
+    crv_whale = ape.accounts["0x7a16ff8270133f063aab6c9977183d9e72835428"]
+    crv_token = ape.Contract(CRV)
+    voting_escrow = ape.Contract(VOTING_ESCROW)
+    # greater than 2500 so we can avoid fiddly issues
+    amount = 3000 * 10**18
+    crv_token.transfer(user.address, amount, sender=crv_whale)
+    # max lock for 4 years
+    locktime = ape.chain.pending_timestamp + 86400 * 365 * 4
+    crv_token.approve(voting_escrow.address, amount, sender=user)
+    voting_escrow.create_lock(amount, locktime, sender=user)
+    return user

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,8 +34,12 @@ def vote_deployer():
     """
     user = ape.accounts.test_accounts[0]
     crv_whale = ape.accounts["0x7a16ff8270133f063aab6c9977183d9e72835428"]
+    # We seed the whale with lotsa ETH just in case.
+    crv_whale.balance += 100 * 10**18
+
     crv_token = ape.Contract(CRV)
     voting_escrow = ape.Contract(VOTING_ESCROW)
+
     # greater than 2500 so we can avoid fiddly issues
     amount = 3000 * 10**18
     crv_token.transfer(user.address, amount, sender=crv_whale)

--- a/tests/test_decode_vote.py
+++ b/tests/test_decode_vote.py
@@ -1,13 +1,4 @@
-import ape
-import pytest
-
-from curve_dao.addresses import CURVE_DAO_OWNERSHIP
-from curve_dao.modules.smartwallet_checker import (
-    SMARTWALLET_CHECKER,
-    whitelist_vecrv_lock,
-)
-from curve_dao.simulate import simulate
-from curve_dao.vote_utils import decode_vote_script, get_vote_script, make_vote
+from curve_dao.vote_utils import decode_vote_script, get_vote_script
 
 
 def test_decode_vote_script_ownership(vote_deployer):

--- a/tests/test_decode_vote.py
+++ b/tests/test_decode_vote.py
@@ -1,8 +1,10 @@
 import ape
 import pytest
 from curve_dao.addresses import CURVE_DAO_OWNERSHIP
-from curve_dao.modules.smartwallet_checker import (SMARTWALLET_CHECKER,
-                                                   whitelist_vecrv_lock)
+from curve_dao.modules.smartwallet_checker import (
+    SMARTWALLET_CHECKER,
+    whitelist_vecrv_lock,
+)
 from curve_dao.simulate import simulate
 from curve_dao.vote_utils import decode_vote_script, get_vote_script, make_vote
 

--- a/tests/test_decode_vote.py
+++ b/tests/test_decode_vote.py
@@ -1,5 +1,6 @@
 import ape
 import pytest
+
 from curve_dao.addresses import CURVE_DAO_OWNERSHIP
 from curve_dao.modules.smartwallet_checker import (
     SMARTWALLET_CHECKER,

--- a/tests/test_decode_vote.py
+++ b/tests/test_decode_vote.py
@@ -1,0 +1,70 @@
+import ape
+import pytest
+from curve_dao.addresses import CURVE_DAO_OWNERSHIP
+from curve_dao.modules.smartwallet_checker import (SMARTWALLET_CHECKER,
+                                                   whitelist_vecrv_lock)
+from curve_dao.simulate import simulate
+from curve_dao.vote_utils import decode_vote_script, get_vote_script, make_vote
+
+
+def test_decode_vote_script_ownership(vote_deployer):
+    vote_id = 404
+    script = get_vote_script(vote_id, "ownership")
+    votes = decode_vote_script(script)
+
+    expected_votes = [
+        {
+            "agent": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+            "target": "0xbeF434E2aCF0FBaD1f0579d2376fED0d1CfC4217",
+            "function": "price_w",
+            "inputs": [],
+        },
+        {
+            "agent": "0x40907540d8a6C65c637785e8f8B742ae6b0b9968",
+            "target": "0xC9332fdCB1C491Dcc683bAe86Fe3cb70360738BC",
+            "function": "add_market",
+            "inputs": [
+                ("token", "0x18084fbA666a33d37592fA2633fD49a74DD93a88"),
+                ("A", 100),
+                ("fee", 6000000000000000),
+                ("admin_fee", 0),
+                (
+                    "_price_oracle_contract",
+                    "0xbeF434E2aCF0FBaD1f0579d2376fED0d1CfC4217",
+                ),
+                ("monetary_policy", "0xb8687d7dc9d8fa32fabde63E19b2dBC9bB8B2138"),
+                ("loan_discount", 90000000000000000),
+                ("liquidation_discount", 60000000000000000),
+                ("debt_ceiling", 50000000000000000000000000),
+            ],
+        },
+    ]
+    for vote, expected_vote in zip(votes, expected_votes):
+        assert vote["agent"] == expected_vote["agent"]
+        assert vote["target"] == expected_vote["target"]
+        assert vote["function"] == expected_vote["function"]
+        assert vote["inputs"] == expected_vote["inputs"]
+
+
+def test_decode_vote_script_parameter(vote_deployer):
+    vote_id = 69
+    script = get_vote_script(vote_id, "parameter")
+    votes = decode_vote_script(script)
+
+    expected_votes = [
+        {
+            "agent": "0x4EEb3bA4f221cA16ed4A0cC7254E2E32DF948c5f",
+            "target": "0xeCb456EA5365865EbAb8a2661B0c503410e9B347",
+            "function": "commit_new_fee",
+            "inputs": [
+                ("_pool", "0xDC24316b9AE028F1497c275EB9192a3Ea0f67022"),
+                ("new_fee", 1000000),
+                ("new_admin_fee", 5000000000),
+            ],
+        }
+    ]
+    for vote, expected_vote in zip(votes, expected_votes):
+        assert vote["agent"] == expected_vote["agent"]
+        assert vote["target"] == expected_vote["target"]
+        assert vote["function"] == expected_vote["function"]
+        assert vote["inputs"] == expected_vote["inputs"]

--- a/tests/test_kill_gauge.py
+++ b/tests/test_kill_gauge.py
@@ -1,5 +1,6 @@
 import ape
 import pytest
+
 from curve_dao.addresses import CRYPTOSWAP_OWNER_PROXY, CURVE_DAO_OWNERSHIP
 from curve_dao.simulate import simulate
 from curve_dao.vote_utils import make_vote

--- a/tests/test_kill_gauge.py
+++ b/tests/test_kill_gauge.py
@@ -1,7 +1,6 @@
 import ape
 import pytest
-
-from curve_dao import CRYPTOSWAP_OWNER_PROXY, CURVE_DAO_OWNERSHIP
+from curve_dao.addresses import CRYPTOSWAP_OWNER_PROXY, CURVE_DAO_OWNERSHIP
 from curve_dao.simulate import simulate
 from curve_dao.vote_utils import make_vote
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,7 +1,10 @@
 import ape
 import pytest
-
-from curve_dao import CRYPTOSWAP_OWNER_PROXY, CURVE_DAO_OWNERSHIP, CURVE_DAO_PARAM
+from curve_dao.addresses import (
+    CRYPTOSWAP_OWNER_PROXY,
+    CURVE_DAO_OWNERSHIP,
+    CURVE_DAO_PARAM,
+)
 from curve_dao.simulate import simulate
 from curve_dao.vote_utils import make_vote
 

--- a/tests/test_parameter.py
+++ b/tests/test_parameter.py
@@ -1,5 +1,6 @@
 import ape
 import pytest
+
 from curve_dao.addresses import (
     CRYPTOSWAP_OWNER_PROXY,
     CURVE_DAO_OWNERSHIP,

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -1,5 +1,6 @@
 import ape
 import pytest
+
 from curve_dao.addresses import CURVE_DAO_OWNERSHIP
 from curve_dao.modules.smartwallet_checker import (
     SMARTWALLET_CHECKER,

--- a/tests/test_whitelist.py
+++ b/tests/test_whitelist.py
@@ -1,7 +1,6 @@
 import ape
 import pytest
-
-from curve_dao import CURVE_DAO_OWNERSHIP
+from curve_dao.addresses import CURVE_DAO_OWNERSHIP
 from curve_dao.modules.smartwallet_checker import (
     SMARTWALLET_CHECKER,
     whitelist_vecrv_lock,


### PR DESCRIPTION
- future-proof import from eth-abi library (decoding will break without this in later versions of Ape)
- separate out pretty printing from decoding logic; this also lets the decoder be used programatically in scripts
- get description from IPFS to print during decoding
- improve `vote_deployer` fixture as right now tests will fail if the real user on mainnet creates a vote
- added tests for decoding votes (can more easily do that because of the refactor)
- various module reorganization and renaming of functions for readability and consistency